### PR TITLE
feat: implement history heuristic for move ordering

### DIFF
--- a/pkg/board/move/ordered.go
+++ b/pkg/board/move/ordered.go
@@ -16,7 +16,8 @@ package move
 // the following core types may represent move evaluations
 // uint64 is excluded to prevent overflows during storage
 type eval interface {
-	~uint | ~uint8 | ~uint16 | ~uint32
+	~int | ~int8 | ~int16 | ~int32 |
+		~uint | ~uint8 | ~uint16 | ~uint32
 }
 
 // ScoreMoves scores each move in the provided move-list according to the

--- a/pkg/search/eval/move.go
+++ b/pkg/search/eval/move.go
@@ -17,13 +17,14 @@ import (
 	"laptudirm.com/x/mess/pkg/board/mailbox"
 	"laptudirm.com/x/mess/pkg/board/move"
 	"laptudirm.com/x/mess/pkg/board/piece"
+	"laptudirm.com/x/mess/pkg/board/square"
 )
 
 // MoveFunc represents a move evaluation function.
 type MoveFunc func(move.Move) Move
 
 // Move represents the evaluation of a move.
-type Move uint16
+type Move int32
 
 // constants representing move evaluations
 const (
@@ -33,8 +34,6 @@ const (
 
 	KillerMove1 Move = 42000
 	KillerMove2 Move = 41000
-
-	DefaultMove Move = 0
 )
 
 // MvvLva table taken from Blunder
@@ -76,8 +75,7 @@ func OfMove(info ModeEvalInfo) MoveFunc {
 			return KillerMove2
 
 		default:
-			// default move evaluation
-			return DefaultMove
+			return info.History[m.Source()][m.Target()]
 		}
 	}
 }
@@ -85,7 +83,9 @@ func OfMove(info ModeEvalInfo) MoveFunc {
 // MoveEvalInfo stores the various search specific information which are
 // required by the move ordering function.
 type ModeEvalInfo struct {
-	Board   *mailbox.Board
-	PVMove  move.Move
+	Board  *mailbox.Board
+	PVMove move.Move
+
 	Killers [2]move.Move
+	History *[square.N][square.N]Move
 }

--- a/pkg/search/eval/move.go
+++ b/pkg/search/eval/move.go
@@ -28,12 +28,12 @@ type Move int32
 
 // constants representing move evaluations
 const (
-	PVMove Move = 60000
+	PVMove Move = 2000000000
 
-	MvvLvaOffset Move = 50000
+	MvvLvaOffset Move = 1900000000
 
-	KillerMove1 Move = 42000
-	KillerMove2 Move = 41000
+	KillerMove1 Move = 1820000000
+	KillerMove2 Move = 1810000000
 )
 
 // MvvLva table taken from Blunder

--- a/pkg/search/negamax.go
+++ b/pkg/search/negamax.go
@@ -100,6 +100,8 @@ func (search *Context) negamax(plys, depth int, alpha, beta eval.Eval, pv *move.
 		}
 	}
 
+	historyBonus := depthBonus(depth)
+
 	// move ordering; score the generated moves
 	list := move.ScoreMoves(moves, eval.OfMove(eval.ModeEvalInfo{
 		Board:   &search.Board.Position,
@@ -146,19 +148,17 @@ func (search *Context) negamax(plys, depth int, alpha, beta eval.Eval, pv *move.
 				pv.Update(move, childPV)
 
 				if alpha >= beta {
-					search.storeKiller(plys, move)
-					// history bonus
-					search.updateHistory(move, depthBonus(depth))
+					// move ordering heuristics
+					search.storeKiller(plys, move)           // killer move
+					search.updateHistory(move, historyBonus) // history bonus
+
 					break // fail high
-				} else {
-					// history penalty
-					search.updateHistory(move, -depthBonus(depth))
 				}
-			} else {
-				// history penalty
-				search.updateHistory(move, -depthBonus(depth))
 			}
 		}
+
+		// beta wasn't raised, so give move a history penalty
+		search.updateHistory(move, -historyBonus)
 	}
 
 	// if search is stopped, score may be of a bad quality and

--- a/pkg/search/negamax.go
+++ b/pkg/search/negamax.go
@@ -154,6 +154,9 @@ func (search *Context) negamax(plys, depth int, alpha, beta eval.Eval, pv *move.
 					// history penalty
 					search.updateHistory(move, -depthBonus(depth))
 				}
+			} else {
+				// history penalty
+				search.updateHistory(move, -depthBonus(depth))
 			}
 		}
 	}

--- a/pkg/search/negamax.go
+++ b/pkg/search/negamax.go
@@ -105,6 +105,7 @@ func (search *Context) negamax(plys, depth int, alpha, beta eval.Eval, pv *move.
 		Board:   &search.Board.Position,
 		PVMove:  bestMove,
 		Killers: search.killers[plys],
+		History: &search.history[search.Board.SideToMove],
 	}))
 
 	for i := 0; i < list.Length; i++ {
@@ -146,7 +147,12 @@ func (search *Context) negamax(plys, depth int, alpha, beta eval.Eval, pv *move.
 
 				if alpha >= beta {
 					search.storeKiller(plys, move)
+					// history bonus
+					search.updateHistory(move, depthBonus(depth))
 					break // fail high
+				} else {
+					// history penalty
+					search.updateHistory(move, -depthBonus(depth))
 				}
 			}
 		}

--- a/pkg/search/search.go
+++ b/pkg/search/search.go
@@ -22,6 +22,8 @@ import (
 	"laptudirm.com/x/mess/internal/util"
 	"laptudirm.com/x/mess/pkg/board"
 	"laptudirm.com/x/mess/pkg/board/move"
+	"laptudirm.com/x/mess/pkg/board/piece"
+	"laptudirm.com/x/mess/pkg/board/square"
 	"laptudirm.com/x/mess/pkg/search/eval"
 	"laptudirm.com/x/mess/pkg/search/time"
 	"laptudirm.com/x/mess/pkg/search/tt"
@@ -65,6 +67,7 @@ type Context struct {
 	limits Limits
 
 	// move ordering stuff
+	history [piece.ColorN][square.N][square.N]eval.Move
 	killers [MaxDepth][2]move.Move
 }
 
@@ -200,6 +203,26 @@ func (search *Context) storeKiller(plys int, killer move.Move) {
 		search.killers[plys][1] = search.killers[plys][0]
 		search.killers[plys][0] = killer // new killer 1
 	}
+}
+
+// updateHistory updates the history score of the given move with the given
+// bonus. It also verifies that the move is a quiet move.
+func (search *Context) updateHistory(m move.Move, bonus eval.Move) {
+	if !m.IsCapture() {
+		entry := search.fetchHistory(m)
+		hhBonus := bonus - *entry*util.Abs(bonus)/16384
+		*entry += hhBonus
+	}
+}
+
+// depthBonus returns the the history bonus for a particular depth.
+func depthBonus(depth int) eval.Move {
+	return eval.Move(util.Min(2000, depth*155))
+}
+
+// fetchHistory returns a pointer to the history entry of the given move.
+func (search *Context) fetchHistory(move move.Move) *eval.Move {
+	return &search.history[search.Board.SideToMove][move.Source()][move.Target()]
 }
 
 // Limits contains the various limits which decide how long a search can

--- a/pkg/search/search.go
+++ b/pkg/search/search.go
@@ -210,7 +210,7 @@ func (search *Context) storeKiller(plys int, killer move.Move) {
 func (search *Context) updateHistory(m move.Move, bonus eval.Move) {
 	if !m.IsCapture() {
 		entry := search.fetchHistory(m)
-		hhBonus := bonus - *entry*util.Abs(bonus)/16384
+		hhBonus := bonus - *entry*util.Abs(bonus)/32768
 		*entry += hhBonus
 	}
 }


### PR DESCRIPTION
```
ELO   | 15.48 +- 9.03 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 4536 W: 1908 L: 1706 D: 922
```