### PR TITLE
feat: implement late move reduction

### DIFF
--- a/internal/util/math.go
+++ b/internal/util/math.go
@@ -46,3 +46,9 @@ func Abs[T number](x T) T {
 
 	return x
 }
+
+// Clamp returns a value between min and max. If n is between min and max,
+// n is returned, otherwise the closest limit is returned.
+func Clamp[T number](n, min, max T) T {
+	return Max(min, Min(n, max))
+}

--- a/pkg/board/board.go
+++ b/pkg/board/board.go
@@ -61,6 +61,15 @@ type Board struct {
 	EnPassantTarget square.Square
 	CastlingRights  castling.Rights
 
+	// UtilityInfo stores a pointer to the information
+	// generated during move generates, which includes many
+	// expensive but useful board properties.
+	//
+	// A call to GenerateMoves is required to ensure that this
+	// pointer carries up to date information, and it is the
+	// responsibility of the user to ensure that.
+	UtilityInfo *moveGenState
+
 	// move counters
 	Plys      int
 	FullMoves int

--- a/pkg/board/movegen.go
+++ b/pkg/board/movegen.go
@@ -43,6 +43,8 @@ func (b *Board) GenerateMoves(tacticalOnly bool) []move.Move {
 	// king moves are always possible
 	state.appendKingMoves()
 
+	b.UtilityInfo = &state
+
 	return state.MoveList
 }
 

--- a/pkg/search/reductions.go
+++ b/pkg/search/reductions.go
@@ -1,0 +1,36 @@
+// Copyright © 2023 Rak Laptudirm <rak@laptudirm.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package search
+
+import (
+	"math/bits"
+)
+
+// LMR reductions indexed by depth and move number.
+var reductions [MaxDepth][128]int
+
+func init() {
+	reductions[0][0] = 0
+
+	log := func(n int) int {
+		// fast log2 approximation
+		return 63 - bits.LeadingZeros64(uint64(n))
+	}
+
+	for depth := 1; depth < MaxDepth; depth++ {
+		for moves := 1; moves < 128; moves++ {
+			reductions[depth][moves] = 1 + log(depth)*log(moves)/2
+		}
+	}
+}

--- a/pkg/search/reductions.go
+++ b/pkg/search/reductions.go
@@ -18,7 +18,7 @@ import (
 )
 
 // LMR reductions indexed by depth and move number.
-var reductions [MaxDepth][128]int
+var reductions [MaxDepth + 1][128]int
 
 func init() {
 	reductions[0][0] = 0
@@ -28,7 +28,7 @@ func init() {
 		return 63 - bits.LeadingZeros64(uint64(n))
 	}
 
-	for depth := 1; depth < MaxDepth; depth++ {
+	for depth := 1; depth <= MaxDepth; depth++ {
 		for moves := 1; moves < 128; moves++ {
 			reductions[depth][moves] = 1 + log(depth)*log(moves)/2
 		}


### PR DESCRIPTION
```
ELO   | 236.47 +- 47.26 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 272 W: 192 L: 31 D: 49
```