### PR TITLE
feat: better tt replacement scheme

### DIFF
--- a/pkg/search/search.go
+++ b/pkg/search/search.go
@@ -124,6 +124,9 @@ func (search *Context) start(limits Limits) {
 	// reset stats
 	search.stats = Stats{}
 
+	// age the transposition table
+	search.tt.NextEpoch()
+
 	// start search
 	search.stopped = false           // search not stopped
 	search.limits.Time.GetDeadline() // get search deadline

--- a/pkg/search/tt/table.go
+++ b/pkg/search/tt/table.go
@@ -17,6 +17,7 @@
 package tt
 
 import (
+	"math/bits"
 	"reflect"
 
 	"laptudirm.com/x/mess/pkg/board/move"
@@ -97,8 +98,11 @@ func (tt *Table) fetch(hash zobrist.Key) *Entry {
 }
 
 // indexOf is the hash function used by the transposition table.
-func (tt *Table) indexOf(hash zobrist.Key) int {
-	return int(uint64(hash) % uint64(tt.size))
+func (tt *Table) indexOf(hash zobrist.Key) uint {
+	// fast indexing function from Daniel Lemire's blog post
+	// https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/
+	index, _ := bits.Mul(uint(hash), uint(tt.size))
+	return index
 }
 
 // Entry represents a transposition table entry.


### PR DESCRIPTION
```
ELO   | 71.74 +- 20.11 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.02 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 776 W: 331 L: 173 D: 272
```