### PR TITLE
feat: improve aspiration windows

### DIFF
--- a/pkg/search/aspiration.go
+++ b/pkg/search/aspiration.go
@@ -34,7 +34,7 @@ func (search *Context) aspirationWindow(depth int, prevEval eval.Eval) (eval.Eva
 	initialDepth := depth
 
 	// aspiration window size
-	var windowSize eval.Eval = 50
+	var windowSize eval.Eval = 10
 
 	// only do aspiration search at greater than depth 5
 	if depth >= 5 {

--- a/pkg/search/aspiration.go
+++ b/pkg/search/aspiration.go
@@ -31,6 +31,8 @@ func (search *Context) aspirationWindow(depth int, prevEval eval.Eval) (eval.Eva
 	alpha := eval.Eval(-eval.Inf)
 	beta := eval.Eval(eval.Inf)
 
+	initialDepth := depth
+
 	// aspiration window size
 	var windowSize eval.Eval = 50
 
@@ -53,14 +55,22 @@ func (search *Context) aspirationWindow(depth int, prevEval eval.Eval) (eval.Eva
 		result := search.negamax(0, depth, alpha, beta, &pv)
 
 		switch {
-		// out of bounds check: <= alpha
+		// result <= alpha: search failed low
 		case result <= alpha:
 			beta = (alpha + beta) / 2
 			alpha = util.Max(alpha-windowSize, -eval.Inf)
 
-		// out of bounds check: >= beta
+			// reset reduced depth
+			depth = initialDepth
+
+		// result >= beta: search failed high
 		case result >= beta:
 			beta = util.Min(beta+windowSize, eval.Inf)
+
+			// unless we are mating, reduce depth
+			if util.Abs(result) <= eval.Inf/2 {
+				depth--
+			}
 
 		// exact score is inside bounds
 		default:

--- a/pkg/search/aspiration.go
+++ b/pkg/search/aspiration.go
@@ -68,7 +68,8 @@ func (search *Context) aspirationWindow(depth int, prevEval eval.Eval) (eval.Eva
 			beta = util.Min(beta+windowSize, eval.Inf)
 
 			// unless we are mating, reduce depth
-			if util.Abs(result) <= eval.Inf/2 {
+			if util.Abs(result) <= eval.Inf/2 &&
+				depth > 1 { // don't reduce too much
 				depth--
 			}
 


### PR DESCRIPTION
```
ELO   | 72.13 +- 19.91 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 728 W: 293 L: 144 D: 291
```
# Changes
- [x] Decrease search depth on fail highs (from Stockfish) (~5 elo)
- [x] Decrease Aspiration Window Initial size from 50 to 10 (~65 elo)