### PR TITLE
feat: reduce tt-entry size

### DIFF
--- a/pkg/board/move/move.go
+++ b/pkg/board/move/move.go
@@ -27,7 +27,7 @@ import (
 // [20 isCapture bool 20] \
 // [19 toPiece piece.Piece 16][15 fromPiece piece.Piece 12] \
 // [11 target square.Square 6][05 source square.Square  00]
-type Move uint
+type Move uint32
 
 // MaxN is the maximum number of plys in a chess game.
 const MaxN = 1024

--- a/pkg/search/negamax.go
+++ b/pkg/search/negamax.go
@@ -102,7 +102,7 @@ func (search *Context) negamax(plys, depth int, alpha, beta eval.Eval, pv *move.
 
 		// only use entry if current node is not a pv node and
 		// entry depth is >= current depth (not worse quality)
-		if !isPVNode && !isNullMove && entry.Depth >= depth {
+		if !isPVNode && !isNullMove && int(entry.Depth) >= depth {
 			search.stats.TTHits++
 
 			// check if the tt entry can be used to exit the search early
@@ -298,7 +298,7 @@ func (search *Context) negamax(plys, depth int, alpha, beta eval.Eval, pv *move.
 			Hash:  search.board.Hash,
 			Value: tt.EvalFrom(bestScore, plys),
 			Move:  bestMove,
-			Depth: depth,
+			Depth: uint8(depth),
 			Type:  entryType,
 		})
 	}

--- a/pkg/search/tt/table.go
+++ b/pkg/search/tt/table.go
@@ -44,7 +44,7 @@ func NewTable(mbs int) *Table {
 type Table struct {
 	table []Entry // hash table
 	size  int     // table size
-	epoch int     // table epoch
+	epoch uint8   // table epoch
 }
 
 // NextEpoch increases the epoch number of the given tt.
@@ -112,11 +112,11 @@ type Entry struct {
 	Hash zobrist.Key
 
 	// depth this position was searched to
-	Depth int
+	Depth uint8
 
 	Value Eval      // value of this position
 	Type  EntryType // entry type of the value
-	epoch int       // birth epoch of the entry
+	epoch uint8     // birth epoch of the entry
 
 	// best move in the position
 	// used during iterative deepening as pv move
@@ -125,13 +125,13 @@ type Entry struct {
 
 // quality returns a quality measure of the given tt entry which will be
 // used to determine whether a tt entry should be overwritten or not.
-func (entry *Entry) quality() int {
+func (entry *Entry) quality() uint8 {
 	return entry.epoch + entry.Depth/3
 }
 
 // EntryType represents the type of a transposition table entry's
 // value, whether it exists, it is upper bound, lower bound, or exact.
-type EntryType byte
+type EntryType uint8
 
 // constants representing various transposition table entry types
 const (

--- a/pkg/search/tt/table.go
+++ b/pkg/search/tt/table.go
@@ -111,16 +111,17 @@ type Entry struct {
 	// transposition table key collisions
 	Hash zobrist.Key
 
-	// depth this position was searched to
-	Depth uint8
-
-	Value Eval      // value of this position
-	Type  EntryType // entry type of the value
-	epoch uint8     // birth epoch of the entry
-
 	// best move in the position
 	// used during iterative deepening as pv move
 	Move move.Move
+
+	// evaluation info
+	Value Eval      // value of this position
+	Type  EntryType // bound type of the value
+
+	// entry metadata
+	Depth uint8 // depth the position was searched to
+	epoch uint8 // epoch/age of the entry from creation
 }
 
 // quality returns a quality measure of the given tt entry which will be


### PR DESCRIPTION
```
ELO   | 11.61 +- 7.07 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 5208 W: 1550 L: 1376 D: 2282
```