### PR TITLE
feat: implement better time manager

### DIFF
--- a/pkg/search/deepning.go
+++ b/pkg/search/deepning.go
@@ -52,6 +52,10 @@ func (search *Context) iterativeDeepening() (move.Variation, eval.Eval) {
 
 		// print some info for the GUI
 		search.reporter(search.GenerateReport())
+
+		if search.time.OptimisticExpired() {
+			break
+		}
 	}
 
 	if search.stats.Depth < search.limits.Depth && search.limits.Infinite {

--- a/pkg/search/deepning.go
+++ b/pkg/search/deepning.go
@@ -53,7 +53,7 @@ func (search *Context) iterativeDeepening() (move.Variation, eval.Eval) {
 		// print some info for the GUI
 		search.reporter(search.GenerateReport())
 
-		if search.time.OptimisticExpired() {
+		if search.time != nil && search.time.OptimisticExpired() {
 			break
 		}
 	}

--- a/pkg/search/limits.go
+++ b/pkg/search/limits.go
@@ -15,7 +15,6 @@ package search
 
 import (
 	"laptudirm.com/x/mess/pkg/board/piece"
-	"laptudirm.com/x/mess/pkg/search/time"
 )
 
 // Limits contains the various limits which decide how long a search can
@@ -47,14 +46,15 @@ func (search *Context) UpdateLimits(limits Limits) {
 		return
 
 	case limits.MoveTime != 0:
-		search.time = &time.MoveManager{Duration: limits.MoveTime}
+		search.time = &TimeManagerMovetime{Duration: limits.MoveTime}
 
 	default:
-		search.time = &time.NormalManager{
+		search.time = &TimeManagerNormal{
 			Time:      limits.Time,
 			Increment: limits.Increment,
 			MovesToGo: limits.MovesToGo,
 			Us:        search.sideToMove,
+			context:   search,
 		}
 	}
 
@@ -82,7 +82,7 @@ func (search *Context) shouldStop() bool {
 
 		return false
 
-	case search.stats.Nodes > search.limits.Nodes, search.time.Expired():
+	case search.stats.Nodes > search.limits.Nodes, search.time.PessimisticExpired():
 		// node limit or time limit crossed
 		search.Stop()
 		return true

--- a/pkg/search/manager.go
+++ b/pkg/search/manager.go
@@ -11,18 +11,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package time implements various types and functions used to manage
-// search time while searching a position.
-package time
+package search
 
 import (
 	"time"
 
+	"laptudirm.com/x/mess/internal/util"
 	"laptudirm.com/x/mess/pkg/board/piece"
 )
 
 // Manager represents a time manager.
-type Manager interface {
+type TimeManager interface {
 	// GetDeadline calculates the optimal amount of time to be used
 	// and sets a deadline internally for the search's end.
 	GetDeadline()
@@ -31,55 +30,74 @@ type Manager interface {
 	// search's length. A deadline extension may fail.
 	ExtendDeadline()
 
-	// Expired reports if the search deadline has been crossed.
-	Expired() bool
+	// PessimisticExpired reports if the search deadline has been crossed.
+	PessimisticExpired() bool
+	OptimisticExpired() bool
 }
 
 // NormalManager is the standard time manager which uses the wtime, btime,
 // winc, binc, and movestogo provided by the GUI to calculate the optimal
 // search time.
-type NormalManager struct {
+type TimeManagerNormal struct {
 	Us piece.Color // side to move
 
 	Time, Increment [piece.ColorN]int
 	MovesToGo       int // moves to next time control
 
 	deadline time.Time // search end deadline
+	maxUsage time.Time
+
+	context *Context
 }
 
 // compile time check that NormalManager implements Manager
-var _ Manager = (*NormalManager)(nil)
+var _ TimeManager = (*TimeManagerNormal)(nil)
 
-func (c *NormalManager) GetDeadline() {
-	c.deadline = time.Now().Add((time.Duration(c.Time[c.Us]) * time.Millisecond) / 20)
+func (c *TimeManagerNormal) GetDeadline() {
+	if c.MovesToGo == 0 {
+		c.MovesToGo = util.Max(20, 50-(c.context.board.Plys/2))
+	}
+
+	maximum := time.Duration(c.Time[c.Us]) * time.Millisecond
+
+	c.deadline = time.Now().Add(maximum / time.Duration(c.MovesToGo))
+	c.maxUsage = time.Now().Add(maximum / 2)
 }
 
-func (c *NormalManager) ExtendDeadline() {
+func (c *TimeManagerNormal) ExtendDeadline() {
 	c.deadline = c.deadline.Add((time.Duration(c.Time[c.Us]) * time.Millisecond) / 30)
 }
 
-func (c *NormalManager) Expired() bool {
+func (c *TimeManagerNormal) PessimisticExpired() bool {
+	return time.Now().After(c.maxUsage)
+}
+
+func (c *TimeManagerNormal) OptimisticExpired() bool {
 	return time.Now().After(c.deadline)
 }
 
 // MoveManger is the time manager used when the gui wants to time a search
 // by move-time. Extending it's deadline is not possible.
-type MoveManager struct {
-	Duration int
+type TimeManagerMovetime struct {
 	deadline time.Time
+	Duration int
 }
 
 // compile time check that MoveManager implements Manager
-var _ Manager = (*MoveManager)(nil)
+var _ TimeManager = (*TimeManagerMovetime)(nil)
 
-func (c *MoveManager) GetDeadline() {
+func (c *TimeManagerMovetime) GetDeadline() {
 	c.deadline = time.Now().Add(time.Duration(c.Duration) * time.Millisecond)
 }
 
-func (c *MoveManager) ExtendDeadline() {
+func (c *TimeManagerMovetime) ExtendDeadline() {
 	// can't extend deadline: search time is fixed
 }
 
-func (c *MoveManager) Expired() bool {
+func (c *TimeManagerMovetime) PessimisticExpired() bool {
+	return time.Now().After(c.deadline)
+}
+
+func (c *TimeManagerMovetime) OptimisticExpired() bool {
 	return time.Now().After(c.deadline)
 }

--- a/pkg/search/search.go
+++ b/pkg/search/search.go
@@ -27,7 +27,6 @@ import (
 	"laptudirm.com/x/mess/pkg/board/square"
 	"laptudirm.com/x/mess/pkg/search/eval"
 	"laptudirm.com/x/mess/pkg/search/eval/classical"
-	"laptudirm.com/x/mess/pkg/search/time"
 	"laptudirm.com/x/mess/pkg/search/tt"
 )
 
@@ -76,7 +75,7 @@ type Context struct {
 	reporter Reporter
 
 	// search limits
-	time   time.Manager
+	time   TimeManager
 	limits Limits
 
 	// move ordering stuff


### PR DESCRIPTION
```
ELO   | 88.74 +- 22.36 (95%)
SPRT  | 40/40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 600 W: 259 L: 109 D: 232
```
https://chess.swehosting.se/test/862/