### PR TITLE
chore: return beta instead of score from nmp

### DIFF
--- a/pkg/search/negamax.go
+++ b/pkg/search/negamax.go
@@ -168,13 +168,7 @@ func (search *Context) negamax(plys, depth int, alpha, beta eval.Eval, pv *move.
 			search.board.UnmakeMove()
 
 			if score >= beta {
-				if score >= eval.WinInMaxPly {
-					// don't return mate evaluations
-					// from the null move search
-					return beta
-				}
-
-				return score
+				return beta
 			}
 		}
 	}


### PR DESCRIPTION
```
ELO   | 8.20 +- 5.77 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 8432 W: 2654 L: 2455 D: 3323
```
https://chess.swehosting.se/test/919/