### PR TITLE
chore: improve see pruning

### DIFF
--- a/internal/build/info.go
+++ b/internal/build/info.go
@@ -17,4 +17,4 @@
 package build
 
 // Current version of Mess. Usually overwritten by the build script.
-const Version = "v0.2.1"
+const Version = "v0.2.2"

--- a/pkg/search/negamax.go
+++ b/pkg/search/negamax.go
@@ -127,13 +127,8 @@ func (search *Context) negamax(plys, depth int, alpha, beta eval.Eval, pv *move.
 	// Internal Iterative Reduction (IIR): If a hash move is not found by
 	// probing the transposition table, do a shallower search, as our move
 	// ordering won't be as effective.
-	if bestMove == move.Null {
-		switch {
-		case depth >= 4:
-			depth -= 1
-		case depth >= 8:
-			depth -= 2
-		}
+	if depth >= 4 && bestMove == move.Null {
+		depth--
 	}
 
 	if !isPVNode && !isCheck {

--- a/pkg/search/negamax.go
+++ b/pkg/search/negamax.go
@@ -127,8 +127,13 @@ func (search *Context) negamax(plys, depth int, alpha, beta eval.Eval, pv *move.
 	// Internal Iterative Reduction (IIR): If a hash move is not found by
 	// probing the transposition table, do a shallower search, as our move
 	// ordering won't be as effective.
-	if depth >= 4 && bestMove == move.Null {
-		depth--
+	if bestMove == move.Null {
+		switch {
+		case depth >= 4:
+			depth -= 1
+		case depth >= 8:
+			depth -= 2
+		}
 	}
 
 	if !isPVNode && !isCheck {
@@ -190,13 +195,23 @@ func (search *Context) negamax(plys, depth int, alpha, beta eval.Eval, pv *move.
 
 		move := list.PickMove(i)
 
-		if bestScore > eval.LoseInMaxPly {
+		if !isPVNode && i > 0 {
 			// Static Exchange Evaluation Pruning (SEE Pruning): If the static exchange
 			// evaluation score of a move is less than a given threshold, we can safely
 			// prune that move since we will take too large a material hit to come back
 			// from.
-			if depth < 6 && !eval.SEE(search.board, move, util.Ternary(move.IsQuiet(), seeQuietMargin, seeNoisyMargin)) {
-				continue
+			if i >= 3 && util.Abs(alpha) < eval.WinInMaxPly {
+				if move.IsQuiet() {
+					// Quiet SEE
+					if depth <= 3 && !eval.SEE(search.board, move, seeQuietMargin) {
+						continue
+					}
+				} else {
+					// Noisy SEE
+					if depth <= 6 && !eval.SEE(search.board, move, seeNoisyMargin) {
+						continue
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
```
ELO   | 5.61 +- 4.38 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 14608 W: 4535 L: 4299 D: 5774
```
https://chess.swehosting.se/test/924/

### Removing IIR changes:
```
ELO   | -0.07 +- 3.33 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 25312 W: 7664 L: 7669 D: 9979
```
https://chess.swehosting.se/test/928/
