### PR TITLE
feat: implement late move pruning

### DIFF
--- a/internal/build/info.go
+++ b/internal/build/info.go
@@ -17,4 +17,4 @@
 package build
 
 // Current version of Mess. Usually overwritten by the build script.
-const Version = "v0.2.2"
+const Version = "v0.2.3"

--- a/pkg/search/negamax.go
+++ b/pkg/search/negamax.go
@@ -191,6 +191,14 @@ func (search *Context) negamax(plys, depth int, alpha, beta eval.Eval, pv *move.
 		move := list.PickMove(i)
 
 		if !isPVNode && i > 0 {
+			// Late Move Pruning (LMP): If the depth is low enough, we can ignore most
+			// of the moves which are ordered towards the end of the move list as they
+			// probably won't raise alpha anyways. The depth constraint is to make sure
+			// that we don't miss anything at higher depths.
+			if depth <= 3 && i >= depth*10 {
+				break
+			}
+
 			// Static Exchange Evaluation Pruning (SEE Pruning): If the static exchange
 			// evaluation score of a move is less than a given threshold, we can safely
 			// prune that move since we will take too large a material hit to come back


### PR DESCRIPTION
### STC (10+0.01s 16MB)
```
ELO   | 30.58 +- 12.53 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 1800 W: 624 L: 466 D: 710
```

### LTC (60+0.6s 256MB)
```
ELO   | 35.88 +- 13.26 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 1448 W: 469 L: 320 D: 659
```
