### PR TITLE
feat: add insufficient material checks

### DIFF
--- a/pkg/board/board.go
+++ b/pkg/board/board.go
@@ -169,6 +169,39 @@ func (b *Board) IsThreefoldRepetition() bool {
 	return false
 }
 
+func (b *Board) IsInsufficientMaterial() bool {
+	// major pieces can mate a king just with the help of their own king,
+	// and pawns can promote and turn into any of the two major pieces
+	if b.PieceBBs[piece.Queen]|b.PieceBBs[piece.Rook]|b.PieceBBs[piece.Pawn] == bitboard.Empty {
+		var pieceN [piece.ColorN]int
+		pieceN[piece.White] = b.ColorBBs[piece.White].Count()
+		pieceN[piece.Black] = b.ColorBBs[piece.Black].Count()
+
+		loneWhiteKing := pieceN[piece.White] == 1
+		loneBlackKing := pieceN[piece.Black] == 1
+
+		switch {
+		// only kings left on board
+		case loneWhiteKing && loneBlackKing:
+			return true
+
+		// only one side has pieces and it's one minor piece
+		case loneWhiteKing || loneBlackKing:
+			strongerSide := piece.White
+			if loneWhiteKing {
+				strongerSide = piece.Black
+			}
+
+			return pieceN[strongerSide] <= 2
+
+		// TODO: implement the more complicated insufficient material rules
+		default: // both sides have some minor pieces
+		}
+	}
+
+	return false
+}
+
 // ClearSquare removes the piece occupying the given square and updates the
 // dependent position information accordingly.
 func (b *Board) ClearSquare(s square.Square) {

--- a/pkg/search/negamax.go
+++ b/pkg/search/negamax.go
@@ -58,6 +58,7 @@ func (search *Context) negamax(plys, depth int, alpha, beta eval.Eval, pv *move.
 		return 0
 
 	case search.board.DrawClock >= 100,
+		search.board.IsInsufficientMaterial(),
 		plys == 0 && search.board.IsThreefoldRepetition(),
 		plys != 0 && search.board.IsRepetition():
 		// position is draw due to 50-move rule or threefold-repetition

--- a/pkg/search/quiescence.go
+++ b/pkg/search/quiescence.go
@@ -31,6 +31,7 @@ func (search *Context) quiescence(plys int, alpha, beta eval.Eval) eval.Eval {
 		return 0 // return value doesn't matter
 
 	case search.board.DrawClock >= 100,
+		search.board.IsInsufficientMaterial(),
 		search.board.IsRepetition():
 		return search.draw()
 


### PR DESCRIPTION
### Changes

Positions from which no series of legal moves can lead to checkmate for
either side are now considered terminal nodes with a draw score. The
following positions are currently accounted for:
1. KvK
2. KBvK
3. KNvK

<hr>

### [STC](http://findingchess.shaheryarsohail.com/test/86)
```
ELO   | 5.16 +- 4.10 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.94 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 16912 W: 5310 L: 5059 D: 6543
```

### [LTC](http://findingchess.shaheryarsohail.com/test/88)
```
ELO   | 11.59 +- 7.04 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 5096 W: 1475 L: 1305 D: 2316
```