### PR TITLE
feat: state is not allocated every movegen call

### DIFF
--- a/pkg/board/board.go
+++ b/pkg/board/board.go
@@ -36,6 +36,7 @@ func New(config ...boardUpdater) *Board {
 	var board Board
 
 	board.efficientlyUpdatable = &dummyEU{}
+	board.moveGenState = moveGenState{Board: &board}
 
 	for _, updater := range config {
 		updater(&board)
@@ -90,14 +91,7 @@ type Board struct {
 
 	efficientlyUpdatable EfficientlyUpdatable
 
-	// UtilityInfo stores a pointer to the information
-	// generated during move generates, which includes many
-	// expensive but useful board properties.
-	//
-	// A call to GenerateMoves is required to ensure that this
-	// pointer carries up to date information, and it is the
-	// responsibility of the user to ensure that.
-	UtilityInfo *moveGenState
+	moveGenState moveGenState
 
 	// move counters
 	Plys      int

--- a/pkg/board/movegen.go
+++ b/pkg/board/movegen.go
@@ -26,26 +26,23 @@ import (
 // the current position.
 func (b *Board) GenerateMoves(tacticalOnly bool) []move.Move {
 	// initialize movegen state
-	state := moveGenState{Board: b}
-	state.Init(tacticalOnly)
+	b.moveGenState.Init(tacticalOnly)
 
 	// append moves to movelist
-	if state.CheckN < 2 {
+	if b.moveGenState.CheckN < 2 {
 		// moves of other pieces are only possible
 		// if the king is not in double check
-		state.appendPawnMoves()
-		state.appendKnightMoves()
-		state.appendBishopMoves()
-		state.appendRookMoves()
-		state.appendQueenMoves()
+		b.moveGenState.appendPawnMoves()
+		b.moveGenState.appendKnightMoves()
+		b.moveGenState.appendBishopMoves()
+		b.moveGenState.appendRookMoves()
+		b.moveGenState.appendQueenMoves()
 	}
 
 	// king moves are always possible
-	state.appendKingMoves()
+	b.moveGenState.appendKingMoves()
 
-	b.UtilityInfo = &state
-
-	return state.MoveList
+	return b.moveGenState.MoveList
 }
 
 func (s *moveGenState) appendKingMoves() {


### PR DESCRIPTION
### Changes

The move generation state object is now no longer reallocated on every call to
`(*board).GenerateMoves()`. It is now represented as a field on the board struct
which gets rid of a lot of unnecessary allocation and makes the engine much faster.

### [Short Time Control](http://findingchess.shaheryarsohail.com/test/92)

```
ELO   | 21.36 +- 10.42 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 2736 W: 957 L: 789 D: 990
```

### [Long Time Control](findingchess.shaheryarsohail.com/test/94)

```
ELO   | 14.01 +- 7.90 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 4120 W: 1227 L: 1061 D: 1832
```